### PR TITLE
Replace pkg_resources with importlib.metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 CLI Tools for investigating game files and extracting known packages
 
 ## Requirements
-- Python 3.9 - 3.11
+- Python 3.9 - 3.12
   - This should be a final release, especially if on Windows / C++ build tools aren't installed
 - PIPx
 

--- a/src/gex/commands/version.py
+++ b/src/gex/commands/version.py
@@ -1,8 +1,8 @@
 import click
-import pkg_resources
+from importlib import metadata
 
 @click.command()
 def version():
     """Return build info"""
-    version = pkg_resources.get_distribution('game-extraction-toolbox').version
+    version = metadata.version('game-extraction-toolbox')
     print(f'Game Extraction Toolbox v{version}')


### PR DESCRIPTION
Installing game-extraction-toolbox with pipx under Python 3.12 doesn't work as the pkg_resources module is not included. As this module is deprecated, this replaces it with importlib.metadata instead.