### PR TITLE
Adds alternate revisions to Mega Man X Legacy Collection

### DIFF
--- a/src/gex/lib/tasks/impl/mmxlc1/metadata.json
+++ b/src/gex/lib/tasks/impl/mmxlc1/metadata.json
@@ -30,6 +30,22 @@
                 }
             },
             {
+                "game": "Rockman X (r1)",
+                "system": "SNES",
+                "filename": "rockmanxr1.sfc",
+                "status": "good",
+                "notes": [],
+                "verify": {
+                    "type": "crc",
+                    "crc": "5584641E",
+                    "size": 1572864
+                },
+                "sections": {
+                    "prg0": {"start": "0xD0C4E0", "length": "0x80000"},
+                    "prg1": {"start": "0xC0C4E0", "length": "0x100000"}
+                }
+            },
+            {
                 "game": "Rockman X2",
                 "system": "SNES",
                 "filename": "rockmanx2.sfc",
@@ -72,6 +88,22 @@
                 },
                 "sections": {
                     "prg": {"start": "0xD8C4E0", "length": "0x180000"}
+                }
+            },
+            {
+                "game": "Mega Man X (r1)",
+                "system": "SNES",
+                "filename": "megamanxr1.sfc",
+                "status": "good",
+                "notes": [],
+                "verify": {
+                    "type": "crc",
+                    "crc": "0D9BE382",
+                    "size": 1572864
+                },
+                "sections": {
+                    "prg0": {"start": "0xF0C4E0", "length": "0x80000"},
+                    "prg1": {"start": "0xE0C4E0", "length": "0x100000"}
                 }
             },
             {


### PR DESCRIPTION
The rev. 1 versions of Mega Man X and Rockman X appear to be contained as well, but it's a bit tricky. Only the part of each ROM different from the respective rev. 0 version is stored. This change grabs the starting 0x80000 byte chunks of each rev. 1 version and then fills them in with the remaining 0x100000 bytes from the rev. 0 versions. I'm not positive, but I expect the latter 0x100000 byte chunk is all graphics data which was not changed between revisions. When I tried to extract the whole ROM sequentially it still loaded in an emulator but with garbled graphics. I have verified that the resulting rev. 1 version of Rockman X matches the hash for "Rockman X (Japan) (Rev 1)" in the No-Intro database.

Notably, the rev. 1 version of Mega Man X still contains the text "LICENSED BY NINTENDO" which was removed from the other version.