### PR TITLE
fixing missing file error in genesis task

### DIFF
--- a/src/gex/lib/tasks/impl/genesis/__init__.py
+++ b/src/gex/lib/tasks/impl/genesis/__init__.py
@@ -28,6 +28,8 @@ There are a few more regional variants that are only available in PAK files, but
         '''Copy/rename the ROM files'''
         for file_metadata in self._metadata['in']['files'].values():
             resolved_file = self.read_datafile(in_dir, file_metadata)
+            if not resolved_file:  # these games are bought separately; some might not be installed
+                continue
             if 'copy_to' in file_metadata:
                 out_file_entry = [x for x in self._metadata['out']['files'] if x['game'] == file_metadata['copy_to']][0]
 


### PR DESCRIPTION
Games in this bundle are sold _separately_; unless the user bought _all_ of them, this task fails due to a missing file.