### PR TITLE
Implements KoF 97:GM

### DIFF
--- a/src/gex/lib/tasks/impl/kof97_gm/__init__.py
+++ b/src/gex/lib/tasks/impl/kof97_gm/__init__.py
@@ -1,0 +1,89 @@
+'''Implementation of kof97: The King of Fighters '97: Global Match on Steam and Amazon'''
+import logging
+import os
+from gex.lib.tasks.basetask import BaseTask
+from gex.lib.tasks import helpers
+from gex.lib.utils.blob import transforms
+from gex.lib.utils.vendor import snk
+
+logger = logging.getLogger('gextoolbox')
+
+class KingOfFightersGlobalMatchTask(BaseTask):
+    '''Implements kof97_gm: The King of Fighters '97: Global Match'''
+    _task_name = "kof97_gm"
+    _title = "The King of Fighters '97: Global Match"
+    _details_markdown = '''
+This task covers The King of Fighters '97: Global Match.
+Including both Steam and Amazon Prime Gaming versions.
+
+Based on:
+- https://github.com/RedundantCich/goNCommand/blob/main/GoKOF97
+- https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
+    '''
+    _default_input_folder = helpers.gen_steam_app_default_folder("THE KING OF FIGHTERS '97 GLOBAL MATCH")
+    _input_folder_desc = "Game Library (Amazon, Steam, etc.) folder"
+
+    def get_out_file_info(self):
+        '''Return a list of output files'''
+        return {
+            "files": self._metadata['out']['files'],
+            "notes": self._metadata['out']['notes']
+        }
+
+    def execute(self, in_dir, out_dir):
+        in_files = {}
+        
+        for in_file in self._metadata['in']['files'].values():
+            file_name = in_file['filename']
+            file_path = os.path.join(in_dir, *in_file['rel_path'], file_name)
+            if os.path.exists(file_path):
+                logger.info(f"Found {file_name}...")
+                in_files[file_name] = self.read_datafile(in_dir, in_file)['contents']
+            else:
+                logger.info(f"File {file_name} not found...")
+
+        logger.info("Processing CROM data...")
+
+        crom_odd, crom_even = snk.unswizzle(in_files['c1.bin'])
+
+        [c1, c3, c5] = transforms.custom_split(contents=crom_odd, chunk_sizes=[8388608, 8388608, 4194304])
+
+        [c2, c4, c6] = transforms.custom_split(contents=crom_even, chunk_sizes=[8388608, 8388608, 4194304])
+
+        m1 = in_files['m1.bin']
+
+        [p1, p2] = transforms.custom_split(contents=in_files['p1.bin'], chunk_sizes=[1048576, 4194304])
+        
+        s1 = in_files['s1.bin']
+
+        [v1, v2, v3] = transforms.equal_split(contents=in_files['v1.bin'], num_chunks=3)
+
+        file_map = {
+            '232-c1.c1': c1,
+            '232-c2.c2': c2,
+            '232-c3.c3': c3,
+            '232-c4.c4': c4,
+            '232-c5.c5': c5,
+            '232-c6.c6': c6,
+            '232-m1.m1': m1,
+            "232-p1.p1": p1,
+            "232-p2.sp2": p2,
+            "232-s1.s1": s1,
+            "232-v1.v1": v1,
+            "232-v2.v2": v2,
+            "232-v3.v3": v3,
+        }
+        
+
+        filename = 'kof97.zip'
+        contents = helpers.build_zip(file_map)
+
+        _ = self.verify_out_file(filename, contents)
+
+        out_path = os.path.join(out_dir, filename)
+        with open(out_path, "wb") as out_file:
+            logger.info(f"Writing verified {filename}...")
+            out_file.write(contents)
+
+        logger.info("Processing complete.")
+

--- a/src/gex/lib/tasks/impl/kof97_gm/metadata.json
+++ b/src/gex/lib/tasks/impl/kof97_gm/metadata.json
@@ -1,0 +1,86 @@
+{
+    "in": {
+        "files": {
+            "c1.bin": {
+                "rel_path": ["Data", "rom"],
+                "filename": "c1.bin",
+                "versions": {
+                    "snk": {
+                        "size": 41943040,
+                        "crc": "E9CB47E7"
+                    }
+                }
+            },
+            "m1.bin": {
+                "rel_path": ["Data", "rom"],
+                "filename": "m1.bin",
+                "versions": {
+                    "snk": {
+                        "size": 131072,
+                        "crc": "45348747"
+                    }
+                }
+            },
+            "p1.bin": {
+                "rel_path": ["Data", "rom"],
+                "filename": "p1.bin",
+                "versions": {
+                    "snk": {
+                        "size": 5242880,
+                        "crc": "F2E4C21A"
+                    }
+                }
+            },
+            "s1.bin": {
+                "rel_path": ["Data", "rom"],
+                "filename": "s1.bin",
+                "versions": {
+                    "snk": {
+                        "size": 131072,
+                        "crc": "8514ECF5"
+                    }
+                }
+            },
+            "v1.bin": {
+                "rel_path": ["Data", "rom"],
+                "filename": "v1.bin",
+                "versions": {
+                    "snk": {
+                        "size": 12582912,
+                        "crc": "35656A78"
+                    }
+                }
+            }
+        }
+    },
+    "out": {
+        "files": [
+            {
+                "game": "The King of Fighters '97",
+                "system": "NeoGeo",
+                "filename": "kof97.zip",
+                "status": "playable",
+                "notes": [],
+                "verify": {
+                    "type": "zip",
+                    "entries": {
+                        "232-c1.c1": {"size": 8388608, "crc": "5F8BF0A1"},
+                        "232-c2.c2": {"size": 8388608, "crc": "E4D45C81"},
+                        "232-c3.c3": {"size": 8388608, "crc": "581D6618"},
+                        "232-c4.c4": {"size": 8388608, "crc": "49BB1E68"},
+                        "232-c5.c5": {"size": 4194304, "crc": "34FC4E51"},
+                        "232-c6.c6": {"size": 4194304, "crc": "4FF4D47B"},
+                        "232-m1.m1": {"size": 131072, "crc": "45348747"},
+                        "232-p1.p1": {"size": 1048576, "crc": "7DB81AD9"},
+                        "232-p2.sp2": {"size": 4194304, "crc": "158B23F6"},
+                        "232-s1.s1": {"size": 131072, "crc": "8514ECF5"},
+                        "232-v1.v1": {"size": 4194304, "crc": "22A2B5B5"},
+                        "232-v2.v2": {"size": 4194304, "crc": "2304E744"},
+                        "232-v3.v3": {"size": 4194304, "crc": "759EB954"}
+                    }
+                }
+            }
+        ],
+        "notes": {}
+    }
+}

--- a/src/gex/lib/utils/vendor/snk.py
+++ b/src/gex/lib/utils/vendor/snk.py
@@ -15,3 +15,46 @@ def sfix_reorder(contents):
             tmp[j+ 8] = contents[i+4*j+3]
         contents[i:i+32] = tmp
     return contents
+
+# Based on "ack" post https://www.arcade-projects.com/threads/samurai-shodown-v-perfect-on-real-hardware.13565/page-2
+def unswizzle(data: bytes):
+    odd = bytearray()
+    even = bytearray()
+
+    tile = bytearray(128)
+    offset = bytearray(8)
+    planes = bytearray(4)
+
+    index = 0
+    while index + 128 <= len(data):
+        tile = data[index:index+128]
+        index += 128
+
+        for block in range(4):
+            if block == 0:
+                x_offset, y_offset = 4, 0
+            elif block == 1:
+                x_offset, y_offset = 4, 8
+            elif block == 2:
+                x_offset, y_offset = 0, 0
+            else:
+                x_offset, y_offset = 0, 8
+
+            for row in range(8):
+                planes = bytearray([0, 0, 0, 0])
+                offset = tile[x_offset + (y_offset * 8) + (row * 8): x_offset + (y_offset * 8) + (row * 8) + 8]
+
+                for i in range(3, -1, -1):
+                    offset_data = offset[i]
+                    planes[0] = (planes[0] << 1) | ((offset_data >> 4) & 0x1)
+                    planes[0] = (planes[0] << 1) | ((offset_data >> 0) & 0x1)
+                    planes[1] = (planes[1] << 1) | ((offset_data >> 5) & 0x1)
+                    planes[1] = (planes[1] << 1) | ((offset_data >> 1) & 0x1)
+                    planes[2] = (planes[2] << 1) | ((offset_data >> 6) & 0x1)
+                    planes[2] = (planes[2] << 1) | ((offset_data >> 2) & 0x1)
+                    planes[3] = (planes[3] << 1) | ((offset_data >> 7) & 0x1)
+                    planes[3] = (planes[3] << 1) | ((offset_data >> 3) & 0x1)
+
+                odd.extend(planes[0:2])
+                even.extend(planes[2:4])
+    return odd, even


### PR DESCRIPTION
Closes https://github.com/shawngmc/game-extraction-toolbox/issues/69

Add support to The King of Fighters '97: Global Match (Steam and Amazon Prime Games).

All CRCs matching mame's version.

<details>
  <summary>Game running on RetroArch</summary>
  
![289325459-4105593d-013a-4b7f-a762-e7f2cac2fc96](https://github.com/user-attachments/assets/5454cadc-f727-44ab-97b1-718ad10a8198)

  
![289325445-ddfa8082-fd89-42bb-90a9-05bbb14d39b7](https://github.com/user-attachments/assets/e1a2cbb3-94de-478b-b931-d97ac00a2992)

 </details>